### PR TITLE
Add error messages to `kmcurvely()` when endpoints or subgroup is not defined in the metadata

### DIFF
--- a/R/kmcurvely.R
+++ b/R/kmcurvely.R
@@ -101,6 +101,37 @@ kmcurvely <- function(meta = meta_tte_example(),
   # ----------------------------------------------- #
   endpoint <- unlist(strsplit(endpoint, ";"))
   subgroup <- unlist(strsplit(subgroup, ";"))
+
+  has_parameter_mapping <- function(name) {
+    mapping <- metalite::collect_adam_mapping(meta, name)
+    !is.null(mapping$subset) && !is.null(mapping$label)
+  }
+  undefined_endpoint <- endpoint[!vapply(endpoint, has_parameter_mapping, logical(1))]
+  undefined_subgroup <- subgroup[!vapply(subgroup, has_parameter_mapping, logical(1))]
+
+  mapping_errors <- character()
+  if (length(undefined_endpoint) > 0) {
+    mapping_errors <- c(
+      mapping_errors,
+      paste0("Endpoint(s) not defined in `meta`: ", paste(undefined_endpoint, collapse = ", "))
+    )
+  }
+  if (length(undefined_subgroup) > 0) {
+    mapping_errors <- c(
+      mapping_errors,
+      paste0("Subgroup(s) not defined in `meta`: ", paste(undefined_subgroup, collapse = ", "))
+    )
+  }
+  if (length(mapping_errors) > 0) {
+    stop(
+      paste(
+        c(mapping_errors, "Define each value with `metalite::define_parameter()` before calling `kmcurvely()`."),
+        collapse = "\n"
+      ),
+      call. = FALSE
+    )
+  }
+
   n_endpoint <- length(endpoint)
   n_subgroup <- length(subgroup)
   n_group <- length(unique(obs[[obs_group]]))

--- a/tests/testthat/test-developer-testing-kmcurvely.R
+++ b/tests/testthat/test-developer-testing-kmcurvely.R
@@ -1,0 +1,93 @@
+test_that("kmcurvely reports parameters not defined in meta", {
+  analysis_plan <- metalite::plan(
+    analysis = "km_curvely",
+    population = "apat",
+    observation = "wk12",
+    parameter = "ttde;male"
+  )
+
+  adsl <- kmcurvely_adtte
+  adtte <- kmcurvely_adtte
+
+  meta <- metalite::meta_adam(observation = adtte, population = adsl) |>
+    metalite::define_plan(analysis_plan) |>
+    metalite::define_population(
+      name = "apat",
+      var = c("USUBJID", "SAFFL", "TRTP", "SITEID", "SEX", "RACE", "AGE"),
+      group = "TRTP",
+      subset = SAFFL == "Y",
+      label = "All Participants as Treated"
+    ) |>
+    metalite::define_observation(
+      name = "wk12",
+      var = c("USUBJID", "SAFFL", "TRTP", "SEX", "PARAM", "PARAMCD", "AVAL", "CNSR"),
+      group = "TRTP",
+      subset = SAFFL == "Y",
+      label = "Weeks 0 to 12"
+    ) |>
+    metalite::define_parameter(
+      name = "ttde",
+      subset = PARAMCD == "TTDE",
+      label = "Time to First Dermatologic Event"
+    ) |>
+    metalite::define_parameter(
+      name = "male",
+      subset = SEX == "M",
+      label = "Male"
+    ) |>
+    metalite::define_analysis(
+      name = "km_curvely",
+      title = "KM Plots of All Participants and Subgroups",
+      label = "KM curves"
+    ) |>
+    metalite::meta_build()
+
+  expect_error(
+    kmcurvely(
+      meta = meta,
+      population = "apat",
+      observation = "wk12",
+      endpoint = "ttde;undefined_endpoint",
+      subgroup = "male"
+    ),
+    paste(
+      "Endpoint(s) not defined in `meta`: undefined_endpoint",
+      "Define each value with `metalite::define_parameter()` before calling `kmcurvely()`.",
+      sep = "\n"
+    ),
+    fixed = TRUE
+  )
+
+  expect_error(
+    kmcurvely(
+      meta = meta,
+      population = "apat",
+      observation = "wk12",
+      endpoint = "ttde",
+      subgroup = "male;undefined_subgroup"
+    ),
+    paste(
+      "Subgroup(s) not defined in `meta`: undefined_subgroup",
+      "Define each value with `metalite::define_parameter()` before calling `kmcurvely()`.",
+      sep = "\n"
+    ),
+    fixed = TRUE
+  )
+
+  expect_error(
+    kmcurvely(
+      meta = meta,
+      population = "apat",
+      observation = "wk12",
+      endpoint = "undefined_endpoint",
+      subgroup = "undefined_subgroup"
+    ),
+    paste(
+      "Endpoint(s) not defined in `meta`: undefined_endpoint",
+      "Subgroup(s) not defined in `meta`: undefined_subgroup",
+      "Define each value with `metalite::define_parameter()` before calling `kmcurvely()`.",
+      sep = "\n"
+    ),
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
To solve issue #33 